### PR TITLE
Updated dropbear URL and check for failed download

### DIFF
--- a/bin/build-all.sh
+++ b/bin/build-all.sh
@@ -2,4 +2,6 @@
 
 echo "Building all artifacts."
 $(dirname "$0")/build-galeforce.sh
-$(dirname "$0")/build-image.sh
+if [ $? -eq 0 ]; then
+    $(dirname "$0")/build-image.sh
+fi

--- a/bin/build-galeforce.sh
+++ b/bin/build-galeforce.sh
@@ -4,7 +4,8 @@ pushd $(dirname "$0")
 source ./common.sh
 
 BUSYBOX_URL="https://busybox.net/downloads/binaries/1.26.2-defconfig-multiarch/busybox-armv6l"
-DROPBEAR_URL="http://archive.raspbian.org/raspbian/pool/main/d/dropbear/dropbear-bin_2017.75-1_armhf.deb"
+DROPBEAR_URL="http://archive.raspbian.org/raspbian/pool/main/d/dropbear/dropbear-bin_2016.74-5%2Bdeb9u1_armhf.debc"
+DROPBEAR_BASE_URL="http://archive.raspbian.org/raspbian/pool/main/dropbear"
 
 function downloadBusybox() {
   if [ ! -f "$DOWNLOADS_DIR/busybox" ]
@@ -14,13 +15,25 @@ function downloadBusybox() {
   fi
 }
 
+# go get github.com/ericchiang/pup
+function getDropbearURL() {
+  filename=$(curl -s $DROPBEAR_BASE_URL | pup 'a attr{href}' | grep dropbear-bin | grep 2016)
+  echo $DROPBEAR_BASE_URL/$filename
+}
+
 function downloadDropbear() {
   if [ ! -f "$DOWNLOADS_DIR/dropbear" ]
   then
     echo "Downloading dropbear"
     mkdir -p $DOWNLOADS_DIR/extract
     pushd $DOWNLOADS_DIR/extract
-    curl -s $DROPBEAR_URL -o dropbear.deb
+    curl -sf $DROPBEAR_URL -o dropbear.deb
+    if [ $? -ne 0 ]; then
+      echo Failed to download dropbear - please check DROPBEAR_URL variable in $0
+      exit 1
+    else
+      echo "Downloaded successfully"
+    fi
     ar -x dropbear.deb
     tar -xf data.tar.xz
     cp usr/sbin/dropbear ../

--- a/bin/build-image.sh
+++ b/bin/build-image.sh
@@ -138,7 +138,7 @@ function patchRoot() {
   cat usr/sbin/chromeos-postinst
   # Debug - add telnet
 #  sudo cp galeforce/conf/telnet.conf etc/init
-#  sudo cp galeforce/conf/shadow etc/shadow
+#  sudo cp galeforce/data/shadow etc/shadow
 #  sudo cp galeforce/bin/busybox bin
 #  sudo chmod u+x bin/busybox
 


### PR DESCRIPTION
I have some good news for anyone who has been following this repo... galeforce still works!
Recently I got hold of a couple of spare Google Wifi devices so I had a chance to try the code without breaking my home internet... it took a few tries but I can now reliably flash a new ROM and get SSH root access after a clean recovery reflash from the onhub downloader.

Here's what I had to do to get it working
1. The version of dropbear has changed in the raspbian package archive, so I've updated this to point to an available version that can start up under Chromeos version 9334.41.3 (Official Build).

2. I found that I could not build the image under Vagrant. I'm not entirely sure what the problem is but I'm fairly sure it has to do with reading the image and creating loopback devices while Vagrant is simultaneously presenting the gale.bin file via its own loopback mechanism. 

3. Successful building and flashing to thumb drive was thus done on a bare metal linux machine (Ubuntu 16.04 in my case, but a newer release should work fine too). It may help to manually run kpartx and check the loopback devices are created - this has to work to create the image. You can also mount and check your image contains the galeforce directory just to be sure:

~/code/galeforce/output$ sudo kpartx -av gale.bin
~/code/galeforce/output$ sudo mount /dev/mapper/loop0p3 /mnt




